### PR TITLE
Minor corrections to POM and hbase/Dockerfile

### DIFF
--- a/metron-contrib/metron-docker/compose/hbase/Dockerfile
+++ b/metron-contrib/metron-docker/compose/hbase/Dockerfile
@@ -28,7 +28,7 @@ ADD ./data /data
 ADD ./data-management /data-management
 RUN mkdir -p $METRON_HOME
 RUN tar -xzf /data-management/metron-data-management-$METRON_VERSION-archive.tar.gz -C /usr/metron/$METRON_VERSION/
-ADD http://archive.apache.org/dist/hbase/1.1.6/hbase-1.1.6-bin.tar.gz /tmp
+RUN curl -sL http://archive.apache.org/dist/hbase/1.1.6/hbase-1.1.6-bin.tar.gz | tar -xzC /tmp
 RUN mv /tmp/hbase-1.1.6 /opt/hbase
 RUN yum install -y java-1.8.0-openjdk lsof
 ADD ./conf/enrichment-extractor.json /conf/enrichment-extractor.json

--- a/metron-contrib/metron-docker/pom.xml
+++ b/metron-contrib/metron-docker/pom.xml
@@ -45,7 +45,7 @@
                             <outputDirectory>${project.basedir}/compose/kafkazk/packages</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>../metron-platform/metron-common/target/</directory>
+                                    <directory>${project.parent.parent.basedir}/metron-platform/metron-common/target/</directory>
                                     <includes>
                                         <include>*.tar.gz</include>
                                     </includes>
@@ -63,7 +63,7 @@
                             <outputDirectory>${project.basedir}/compose/kafkazk/packages</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>../metron-platform/metron-parsers/target/</directory>
+                                    <directory>${project.parent.parent.basedir}/metron-platform/metron-parsers/target/</directory>
                                     <includes>
                                         <include>*.tar.gz</include>
                                     </includes>
@@ -81,7 +81,7 @@
                             <outputDirectory>${project.basedir}/compose/kafkazk/packages</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>../metron-platform/metron-enrichment/target/</directory>
+                                    <directory>${project.parent.parent.basedir}/metron-platform/metron-enrichment/target/</directory>
                                     <includes>
                                         <include>*.tar.gz</include>
                                     </includes>
@@ -99,7 +99,7 @@
                             <outputDirectory>${project.basedir}/compose/kafkazk/packages</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>../metron-platform/metron-indexing/target/</directory>
+                                    <directory>${project.parent.parent.basedir}/metron-platform/metron-indexing/target/</directory>
                                     <includes>
                                         <include>*.tar.gz</include>
                                     </includes>
@@ -117,7 +117,7 @@
                             <outputDirectory>${project.basedir}/compose/elasticsearch/es_templates</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>../metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/</directory>
+                                    <directory>${project.parent.parent.basedir}/metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/</directory>
                                     <includes>
                                         <include>*.template</include>
                                     </includes>
@@ -135,7 +135,7 @@
                             <outputDirectory>${project.basedir}/compose/hbase/data-management</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>../metron-platform/metron-data-management/target/</directory>
+                                    <directory>${project.parent.parent.basedir}/metron-platform/metron-data-management/target/</directory>
                                     <includes>
                                         <include>*.tar.gz</include>
                                     </includes>
@@ -153,7 +153,7 @@
                             <outputDirectory>${project.basedir}/compose/storm/parser</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>${project.basedir}/../metron-platform/metron-parsers/target/</directory>
+                                    <directory>${project.parent.parent.basedir}/metron-platform/metron-parsers/target/</directory>
                                     <includes>
                                         <include>*.tar.gz</include>
                                     </includes>
@@ -171,7 +171,7 @@
                             <outputDirectory>${project.basedir}/compose/storm/enrichment</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>${project.basedir}/../metron-platform/metron-enrichment/target/</directory>
+                                    <directory>${project.parent.parent.basedir}/metron-platform/metron-enrichment/target/</directory>
                                     <includes>
                                         <include>*.tar.gz</include>
                                     </includes>
@@ -189,7 +189,7 @@
                             <outputDirectory>${project.basedir}/compose/storm/indexing</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>${project.basedir}/../metron-platform/metron-indexing/target/</directory>
+                                    <directory>${project.parent.parent.basedir}/metron-platform/metron-indexing/target/</directory>
                                     <includes>
                                         <include>*.tar.gz</include>
                                     </includes>
@@ -207,7 +207,7 @@
                             <outputDirectory>${project.basedir}/compose/storm/elasticsearch</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>../metron-platform/metron-elasticsearch/target/</directory>
+                                    <directory>${project.parent.parent.basedir}/metron-platform/metron-elasticsearch/target/</directory>
                                     <includes>
                                         <include>*.tar.gz</include>
                                     </includes>


### PR DESCRIPTION
When running from a clean source tree, maven doesn't copy the resources due to incorrect relative file paths. Corrected this by using the `${project.parent.parent.basedir}` variable.

The ADD command does not auto decompress the tarball in the hbase image. Corrected this to use the style put in place for kafkazk and hadoop images.
